### PR TITLE
Resolved mismatch stubbings in OAuthAuthorizationHeaderTest.java

### DIFF
--- a/src/test/java/com/sap/cloud/alert/notification/client/internal/OAuthAuthorizationHeaderTest.java
+++ b/src/test/java/com/sap/cloud/alert/notification/client/internal/OAuthAuthorizationHeaderTest.java
@@ -88,6 +88,7 @@ public class OAuthAuthorizationHeaderTest {
 
     @Test
     public void givenCertificateAuthentication_andTokenHasExpired_whenGetValueIsCalled_thenTokenIsRenewed() throws Exception {
+        doReturn(null).when(mockedHttpClientFactory).createHttpClient(TEST_CERTIFICATE, TEST_PRIVATE_KEY);
         classUnderTest = new OAuthAuthorizationHeader(TEST_CERTIFICATE, TEST_PRIVATE_KEY, TEST_UAA_URI, TEST_CLIENT_ID, mockedHttpClientFactory);
         when(mockedHttpClient.execute(any(HttpPost.class))) //
                 .thenReturn(createMockedUAATokenResponse(TEST_ACCESS_TOKEN_1, Duration.ofSeconds(1)));


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `givenCertificateAuthentication_andTokenHasExpired_whenGetValueIsCalled_thenTokenIsRenewed`:

* The `createHttpClient` method for the `mockedHttpClientFactory` object:
i) during test execution the method is actually called with arguments `[TEST_CERTIFICATE, TEST_PRIVATE_KEY]`, but is not stubbed, resulting in a mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.